### PR TITLE
Cache user lookups to reduce DB queries per chat message

### DIFF
--- a/src/main/java/net/erstschlag/playground/user/UserCreditsService.java
+++ b/src/main/java/net/erstschlag/playground/user/UserCreditsService.java
@@ -17,6 +17,7 @@ import org.springframework.stereotype.Service;
 public class UserCreditsService {
 
     private final UserRepository userRepository;
+    private final UserService userService;
     private final UserConfiguration userConfiguration;
     private final MapStructMapper mapstructMapper;
     private final ApplicationEventPublisher applicationEventPublisher;
@@ -27,6 +28,7 @@ public class UserCreditsService {
             MapStructMapper mapstructMapper,
             ApplicationEventPublisher applicationEventPublisher) {
         this.userRepository = userRepository;
+        this.userService = userService;
         this.userConfiguration = userConfiguration;
         this.mapstructMapper = mapstructMapper;
         this.applicationEventPublisher = applicationEventPublisher;
@@ -66,7 +68,7 @@ public class UserCreditsService {
     }
 
     private synchronized void modifyUserCredits(String userId, BigDecimal nuggetsChange, String reason, String transactionId) {
-        if (nuggetsChange == BigDecimal.ZERO) {
+        if (nuggetsChange.compareTo(BigDecimal.ZERO) == 0) {
             return;
         }
         UserEntity uE = userRepository.findById(userId).orElse(null);
@@ -76,6 +78,7 @@ public class UserCreditsService {
         if (nuggetsChange.compareTo(BigDecimal.ZERO) >= 0) {
             uE.setNuggets(uE.getNuggets().add(nuggetsChange));
             userRepository.save(uE);
+            userService.invalidateCache(userId);
             applicationEventPublisher.publishEvent(
                     new UserAwardedEvent(
                             mapstructMapper.userEntityToUserDto(uE),
@@ -85,6 +88,7 @@ public class UserCreditsService {
         } else if (hasEnoughNuggets(uE, nuggetsChange.negate())) {
             uE.setNuggets(uE.getNuggets().add(nuggetsChange));
             userRepository.save(uE);
+            userService.invalidateCache(userId);
             applicationEventPublisher.publishEvent(
                     new UserChargedEvent(
                             mapstructMapper.userEntityToUserDto(uE),

--- a/src/main/java/net/erstschlag/playground/user/UserLPRecorder.java
+++ b/src/main/java/net/erstschlag/playground/user/UserLPRecorder.java
@@ -19,13 +19,15 @@ public class UserLPRecorder {
 
     private final EventSubService twitchService;
     private final UserRepository userRepository;
+    private final UserService userService;
     private final HashMap<String, UserDto> eligibleUsersMap = new HashMap<>();
     private final List<String> userBlacklist = new ArrayList<>();
     private boolean lpCollectionEnabled = false;
 
-    public UserLPRecorder(EventSubService eventSubService, UserRepository userRepository, LPConfiguration lpConfiguration) {
+    public UserLPRecorder(EventSubService eventSubService, UserRepository userRepository, UserService userService, LPConfiguration lpConfiguration) {
         this.twitchService = eventSubService;
         this.userRepository = userRepository;
+        this.userService = userService;
         userBlacklist.addAll(Arrays.asList(
                 lpConfiguration.getBlacklist().split(",")));
     }
@@ -52,6 +54,7 @@ public class UserLPRecorder {
                     userEntity.get().setTotalLP(userEntity.get().getTotalLP() + 1);
                     userEntity.get().setWeeklyLP(userEntity.get().getWeeklyLP() + 1);
                     userRepository.save(userEntity.get());
+                    userService.invalidateCache(userEntity.get().getId());
                 }
             }
         }

--- a/src/main/java/net/erstschlag/playground/user/UserService.java
+++ b/src/main/java/net/erstschlag/playground/user/UserService.java
@@ -3,6 +3,7 @@ package net.erstschlag.playground.user;
 import java.math.BigDecimal;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import net.erstschlag.playground.user.repository.UserEntity;
 import net.erstschlag.playground.user.repository.UserRepository;
 import org.springframework.data.domain.Page;
@@ -12,8 +13,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class UserService {
 
+    private static final long CACHE_TTL_MS = 60_000; // 1 minute
+
     private final UserRepository userRepository;
     private final MapStructMapper mapstructMapper;
+    private final ConcurrentHashMap<String, CachedUser> userCache = new ConcurrentHashMap<>();
 
     public UserService(UserRepository userRepository,
             MapStructMapper mapstructMapper) {
@@ -43,6 +47,7 @@ public class UserService {
 
     public void deleteUser(String userId) {
         userRepository.deleteById(userId);
+        userCache.remove(userId);
     }
 
     public Long getWeeklyLPSum() {
@@ -57,7 +62,21 @@ public class UserService {
         userRepository.resetWeeklyLP();
     }
 
+    /**
+     * Invalidates the cached entry for a user so the next lookup hits the DB.
+     * Should be called after external modifications to a user (e.g. credit changes).
+     */
+    public void invalidateCache(String userId) {
+        userCache.remove(userId);
+    }
+
     synchronized UserEntity retrieveOrCreateUser(String userId, String userName) {
+        // Check cache first: if the user is cached, the name matches, and the entry is fresh, skip the DB
+        CachedUser cached = userCache.get(userId);
+        if (cached != null && userName.equals(cached.userName) && !cached.isExpired()) {
+            return cached.entity;
+        }
+
         Optional<UserEntity> oUserEntity = userRepository.findById(userId);
         if (oUserEntity.isPresent()) {
             if (!userName.equals(oUserEntity.get().getName())) {
@@ -65,18 +84,39 @@ public class UserService {
                 oUserEntity.get().setName(userName);
                 userRepository.save(oUserEntity.get());
             }
+            userCache.put(userId, new CachedUser(oUserEntity.get(), userName));
             return oUserEntity.get();
         } else {
             freeupUserName(userName);
-            return userRepository.save(new UserEntity(userId, userName, BigDecimal.ZERO));
+            UserEntity newUser = userRepository.save(new UserEntity(userId, userName, BigDecimal.ZERO));
+            userCache.put(userId, new CachedUser(newUser, userName));
+            return newUser;
         }
     }
-    
+
     private void freeupUserName(String userName) {
         Optional<UserEntity> oExistingUserByName = userRepository.findByName(userName);
         if (oExistingUserByName.isPresent()) {
             oExistingUserByName.get().setName(UUID.randomUUID().toString());
             userRepository.save(oExistingUserByName.get());
+            // Invalidate the old user whose name was freed up
+            userCache.remove(oExistingUserByName.get().getId());
+        }
+    }
+
+    private static class CachedUser {
+        final UserEntity entity;
+        final String userName;
+        final long cachedAt;
+
+        CachedUser(UserEntity entity, String userName) {
+            this.entity = entity;
+            this.userName = userName;
+            this.cachedAt = System.currentTimeMillis();
+        }
+
+        boolean isExpired() {
+            return System.currentTimeMillis() - cachedAt > CACHE_TTL_MS;
         }
     }
 }


### PR DESCRIPTION
Add ConcurrentHashMap cache with 60s TTL to UserService.retrieveOrCreateUser() so repeated lookups for the same user (triggered on every chat message) hit memory instead of issuing up to 3 DB queries each time. Cache is invalidated on credit changes, LP updates, user deletion, and name conflicts.

Also fix BigDecimal.ZERO reference equality bug in UserCreditsService (== replaced with compareTo).